### PR TITLE
Add 9700k to the benchmark queue

### DIFF
--- a/agents/9700k.gpuci3.julia.csail.mit.edu/docker-compose.yml
+++ b/agents/9700k.gpuci3.julia.csail.mit.edu/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,intel=gen9,fastcpu=true
+      - --tags=queue=juliagpu,queue=benchmark,intel=gen9,fastcpu=true
       - --name=9700k.gpuci3.julia.csail.mit.edu
     volumes:
       - /home/buildkite/9700k:/root


### PR DESCRIPTION
It's the same build as gpuci1 so it can be used similarly.

I thought it had an RTX2070 in there?