### PR TITLE
Cyclops: don't allow two different agents (runners) to use the same GPU

### DIFF
--- a/agents/1.cyclops.juliacomputing.io/docker-compose.yml
+++ b/agents/1.cyclops.juliacomputing.io/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     runtime: nvidia
     environment:
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-      NVIDIA_VISIBLE_DEVICES: "GPU-d90c7542-a6bf-616d-6475-29b63dcb6381,GPU-f735dd37-372b-a4c1-f643-cca0b729e13a,GPU-55e75c28-6346-c966-0e96-34cc09111eca,GPU-bf79bede-8a5a-69d2-05b7-cbb616bf1c50,GPU-927aa1fa-4934-95c1-5891-e123b03b9c65"
+      NVIDIA_VISIBLE_DEVICES: "GPU-d90c7542-a6bf-616d-6475-29b63dcb6381"
       JULIA_NUM_THREADS: 3
     pid: "host" #  NVIDIA/gpu-monitoring-tools#63
     env_file: ../token.env
@@ -23,7 +23,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,cuda=9.0,cuda=9.2,cuda=10.0,cuda=10.1,cuda=10.2,cuda=11.0,cuda=11.1,cuda=11.2,cap=sm_75,cap=recent,multigpu
+      - --tags=queue=juliagpu,cuda=9.0,cuda=9.2,cuda=10.0,cuda=10.1,cuda=10.2,cuda=11.0,cuda=11.1,cuda=11.2,cap=sm_75,cap=recent
       - --name=1.cyclops.juliacomputing.io
       - --priority=1
     volumes:

--- a/agents/2.cyclops.juliacomputing.io/docker-compose.yml
+++ b/agents/2.cyclops.juliacomputing.io/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     runtime: nvidia
     environment:
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-      NVIDIA_VISIBLE_DEVICES: "GPU-d90c7542-a6bf-616d-6475-29b63dcb6381,GPU-f735dd37-372b-a4c1-f643-cca0b729e13a,GPU-55e75c28-6346-c966-0e96-34cc09111eca,GPU-bf79bede-8a5a-69d2-05b7-cbb616bf1c50,GPU-927aa1fa-4934-95c1-5891-e123b03b9c65"
+      NVIDIA_VISIBLE_DEVICES: "GPU-f735dd37-372b-a4c1-f643-cca0b729e13a"
       JULIA_NUM_THREADS: 3
     pid: "host" #  NVIDIA/gpu-monitoring-tools#63
     env_file: ../token.env
@@ -23,7 +23,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,cuda=9.0,cuda=9.2,cuda=10.0,cuda=10.1,cuda=10.2,cuda=11.0,cuda=11.1,cuda=11.2,cap=sm_75,cap=recent,multigpu
+      - --tags=queue=juliagpu,cuda=9.0,cuda=9.2,cuda=10.0,cuda=10.1,cuda=10.2,cuda=11.0,cuda=11.1,cuda=11.2,cap=sm_75,cap=recent
       - --name=2.cyclops.juliacomputing.io
       - --priority=1
     volumes:

--- a/agents/3.cyclops.juliacomputing.io/docker-compose.yml
+++ b/agents/3.cyclops.juliacomputing.io/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     runtime: nvidia
     environment:
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-      NVIDIA_VISIBLE_DEVICES: "GPU-d90c7542-a6bf-616d-6475-29b63dcb6381,GPU-f735dd37-372b-a4c1-f643-cca0b729e13a,GPU-55e75c28-6346-c966-0e96-34cc09111eca,GPU-bf79bede-8a5a-69d2-05b7-cbb616bf1c50,GPU-927aa1fa-4934-95c1-5891-e123b03b9c65"
+      NVIDIA_VISIBLE_DEVICES: "GPU-55e75c28-6346-c966-0e96-34cc09111eca,GPU-bf79bede-8a5a-69d2-05b7-cbb616bf1c50,GPU-927aa1fa-4934-95c1-5891-e123b03b9c65"
       JULIA_NUM_THREADS: 3
     pid: "host" #  NVIDIA/gpu-monitoring-tools#63
     env_file: ../token.env


### PR DESCRIPTION
Cyclops has five GPUs:
| Index | UUID  | Description | 
| ----- | ------ | ------------ |
| 0 | `GPU-d90c7542-a6bf-616d-6475-29b63dcb6381` | Tesla V100-PCIE-32GB (sm_70) |
| 1 | `GPU-f735dd37-372b-a4c1-f643-cca0b729e13a` | Tesla V100-PCIE-32GB (sm_70) |
| 2 | `GPU-55e75c28-6346-c966-0e96-34cc09111eca` | Tesla V100-PCIE-32GB (sm_70) |
| 3 | `GPU-bf79bede-8a5a-69d2-05b7-cbb616bf1c50` | Tesla V100-PCIE-32GB (sm_70) |
| 4 | `GPU-927aa1fa-4934-95c1-5891-e123b03b9c65` | Tesla V100-PCIE-16GB (sm_70) |

There are three Buildkite agents (runners) for Cyclops:
1. `1.cyclops.juliacomputing.io`
2. `2.cyclops.juliacomputing.io`
3. `3.cyclops.juliacomputing.io`

Currently, each of the agents is able to see all of the GPU, which means that, for example, if we have one job running on `1.cyclops.juliacomputing.io` and one job running on `2.cyclops.juliacomputing.io`, those two jobs can try to use the same GPU.

Instead, could we try this:
1. `1.cyclops.juliacomputing.io` can see GPU 0
2. `2.cyclops.juliacomputing.io` can see GPU 1
3. `3.cyclops.juliacomputing.io` can see GPUs 2, 3, and 4

@maleadt What do you think about giving this a try?