### PR TITLE
Install Python into the Docker image

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -2,7 +2,7 @@ ARG base=ubuntu:latest
 FROM $base
 
 RUN apt-get update && \
-    apt-get install -y curl wget apt-transport-https openssl gnupg2
+    apt-get install -y curl wget apt-transport-https openssl gnupg2 python3.8
 
 RUN echo 'deb https://apt.buildkite.com/buildkite-agent stable main' >> /etc/apt/sources.list && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 && \


### PR DESCRIPTION
We need Python3 for https://github.com/JuliaCI/julia-buildkite-plugin/pull/4