### PR TITLE
amdgpuci: Add rocmgpu tag

### DIFF
--- a/agents/amdgpuci.1/docker-compose.yml
+++ b/agents/amdgpuci.1/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.1
       - --priority=1
     volumes:

--- a/agents/amdgpuci.2/docker-compose.yml
+++ b/agents/amdgpuci.2/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.2
       - --priority=1
     volumes:

--- a/agents/amdgpuci.3/docker-compose.yml
+++ b/agents/amdgpuci.3/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.3
       - --priority=1
     volumes:

--- a/agents/amdgpuci.4/docker-compose.yml
+++ b/agents/amdgpuci.4/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.4
       - --priority=1
     volumes:

--- a/agents/amdgpuci.5/docker-compose.yml
+++ b/agents/amdgpuci.5/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.5
       - --priority=1
     volumes:

--- a/agents/amdgpuci.6/docker-compose.yml
+++ b/agents/amdgpuci.6/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.6
       - --priority=1
     volumes:

--- a/agents/amdgpuci.7/docker-compose.yml
+++ b/agents/amdgpuci.7/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.7
       - --priority=1
     volumes:

--- a/agents/amdgpuci.8/docker-compose.yml
+++ b/agents/amdgpuci.8/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - start
       - --disconnect-after-job
       - --hooks-path=/hooks
-      - --tags=queue=juliagpu,rocm
+      - --tags=queue=juliagpu,rocm,rocmgpu=gfx908
       - --name=amdgpuci.8
       - --priority=1
     volumes:


### PR DESCRIPTION
This lets us filter based on which kind of GPU is available, which determines the version of ROCm that needs to be available.