### PR TITLE
Change Docker volumes location on AMDGPU runners

### DIFF
--- a/agents/amdgpuci.luraess.1/docker-compose.yml
+++ b/agents/amdgpuci.luraess.1/docker-compose.yml
@@ -23,4 +23,4 @@ services:
       - --name=amdgpu1.luraess.com
       - --priority=1
     volumes:
-      - /home/buildkite/amdgpuci.luraess.1:/root
+      - /data/buildkite/amdgpuci.luraess.1:/root

--- a/agents/amdgpuci.luraess.2/docker-compose.yml
+++ b/agents/amdgpuci.luraess.2/docker-compose.yml
@@ -23,4 +23,4 @@ services:
       - --name=amdgpu2.luraess.com
       - --priority=1
     volumes:
-      - /home/buildkite/amdgpuci.luraess.2:/root
+      - /data/buildkite/amdgpuci.luraess.2:/root


### PR DESCRIPTION
This PR modifies the location where the runners stores data to avoid filling the home partition.